### PR TITLE
Fix Docker: tag images correctly

### DIFF
--- a/docker_push.sh
+++ b/docker_push.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
-docker build -t climatetree:api-gateway .
-docker tag climatetree:api-gateway patelvp/climatetree:api-gateway
-docker push patelvp/climatetree:api-gateway
+docker build -t climatetree-api-gateway .
+docker tag climatetree-api-gateway patelvp/climatetree-api-gateway
+docker push patelvp/climatetree-api-gateway


### PR DESCRIPTION
Images were tagged based on old syntax.
This repo was not updated.